### PR TITLE
More comments + fix makefile for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,50 +18,52 @@
 // https://root.cern.ch/root/htmldoc/guides/users-guide/GettingStarted.html  
 // These will only work for the session you're in. To set them permanently, add them to your .bashrc file, a hidden file in your home directory. The ones I added for Ubuntu 20 were:  
 
-export ROOTSYS=$HOME/root  
-export PATH=$PATH:$ROOTSYS/bin  
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROOTSYS/lib  
-export PROJECT=$HOME/Documents/mu2e/ExampleRootForStudents  // use your directory path  
+`export ROOTSYS=$HOME/root`  
+`export PATH=$PATH:$ROOTSYS/bin`  
+`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROOTSYS/lib`  
+`export PROJECT=$HOME/Documents/mu2e/ExampleRootForStudents`  // use your directory path  
 
-// 
+//  
 // Next, go into the main directory of your ForStudents files, open terminal, type `make clean`, then `make`. This compiles a bunch of necessary files for you.
 
-// 
+//  
 // You'll need to untar the data .root file.  
 // Example untar file 
 
-$ tar xvjf file.tbz
+`$ tar xvjf file.tbz`
 
 // x = extract  
 // v = verbose, verbosely list files processed  
 // j = use bzip2  
 // f = file, take file input
 
-// 
+//  
 // For us
 
-/data$ tar xvjf 1000evn.tbz
+`$ tar xvjf data/1000evn.tbz`
 
 // Example analysis raw data
 
-$ cd macros  
-/macros$ root -l  
-root[0] .L testShowProf_rawevent.cxx  
-root[1] testShowProf_rawevent("path/to/rootfile",100)         //100 is the number of events  
+`$ cd macros`  
+`/macros$ root -l`  
+`root[0] .L testShowProf_rawevent.cxx`  
+`root[1] testShowProf_rawevent("path/to/rootfile",100)`         //100 is the number of events  
 // as of initial commit, the path to the rootfile from the macros folder is "../data/1000evn_v3.root"  
 
-// with root6 in macOS
-$ cd macros
-$ root -l
-root [0] .L testShowProf_rawevent_root6.cxx 
+// with root6 in macOS  
+`$ cd macros`  
+`/macros$ root -l`  
+`root [0] .L testShowProf_rawevent_root6.cxx `
 
+```
 RooFit v3.60 -- Developed by Wouter Verkerke and David Kirkby 
                 Copyright (C) 2000-2013 NIKHEF, University of California & Stanford University
                 All rights reserved, please read http://roofit.sourceforge.net/license.txt
 
 Error in <TCling::RegisterModule>: cannot find dictionary module DataCint_rdict.pcm
+```  
 
 // it shows error here but it can run the macro file.
 
-root [1] testShowProf_rawevent("../data/1000evn_v3.root",100)
+`root [1] testShowProf_rawevent("../data/1000evn_v3.root",100)`
 

--- a/convert_root5_root6.md
+++ b/convert_root5_root6.md
@@ -1,33 +1,24 @@
 Things done to convert from root 5 files to root 6:
 
 
-
-// These define a bunch of variables to use in file paths. I don't know if they're necessary but they're one of the things I did + they're good ideas. You need to add them to the hidden file in your home directory called .bashrc in order to make them permanent. 
-
-export ROOTSYS=$HOME/root  
-export PATH=$PATH:$ROOTSYS/bin  
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROOTSYS/lib  
-export PROJECT=$HOME/Documents/mu2e/ExampleRootForStudents  // use your directory path
+// These define a bunch of variables to use in file paths. I don't know if they're necessary but they're one of the things I did + they're good ideas. You need to add them to the hidden file in your home directory called .bashrc in order to make them permanent.  
+`export ROOTSYS=$HOME/root`  
+`export PATH=$PATH:$ROOTSYS/bin`  
+`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROOTSYS/lib`  
+`export PROJECT=$HOME/Documents/mu2e/ExampleRootForStudents`  // use your directory path
 
 
-
-Add R__LOAD_LIBRARY($PROJECT/libData.so) to the first line of your macro file  
-
+Add `R__LOAD_LIBRARY($PROJECT/libData.so)` to the first line of your macro file  
 
 
-make clean // some of the files in /dataClasses were made on Root 5, we need to delete them all...  
-make // ... and then remake them all here like this
+Run the following in your main directory:  
+`make clean` // In case there are any files compiled on a different system  
+`make` // It's good to compile everything from the same system  
 
-One of the files that should come out in /dataClasses is DataCint_rdict.pcm
+One of the files that should come out in `/dataClasses` is `DataCint_rdict.pcm`
 
-Root 6 uses Cling, an interpreter built as an alternative to the original ROOT interpreter Cint. One of the new features of Root 6 is the compliation of files of some kind into   
-these .pcm files (when there is old Cint files?). Anyway, we need to put that next to the .so file, but it'll probably be generated in /dataClasses, so we need to move it.  
+Root 6 uses Cling, an interpreter built as an alternative to the original ROOT interpreter Cint. One of the new features of Root 6 is the compliation of files of some kind into these .pcm files (when there is old Cint files?). Anyway, we need to put that next to the .so file, but it'll probably be generated in /dataClasses, so we need to move it.  
 In particular, I think DataCint.h is being replaced by DataCint_rdict.pcm. When I did make clean, DataCint.h was removed along with a couple other files, and when I did make, everything else got remade execpt DataCint.h, and I got the new DataCint_rdict.pcm.  
 On the other hand, running `make clean` and `make` with ROOT 5 produces DataCint.h and you don't get any DataCint_rdict.pcm files.
 
 CONCLUSION: ROOT 5 makes a DataCint.h file that can be kept in /dataClasses, ROOT 6 makes a DataCint_rdict.pcm file in its place that must be placed next to the libData.so file.
-
-
-
-If you run into the problem of Root closing with no errors, I'm guessing it's memory overload, so change all the 10,000 in the macro to 100 or 1000.  
-This post (https://root-forum.cern.ch/t/no-error-when-macro-crashes/14931) also implies a command to increase some memory limit but I think that didn't immediately fix it for me so it's better probably to reduce to 100

--- a/makefile
+++ b/makefile
@@ -32,6 +32,14 @@ ifeq ($(OS),Darwin)
 	CC := clang++
 endif
 
+# Clang allows both libc++ or libstdc++, whreas gcc supports only libstdc++, so gcc has no -stdlib command option
+
+ifeq ($(OS),Darwin)
+	STDLIB:=-stdlib=libc++
+else
+	STDLIB:=  # Nothing, as Linux can't use this/doesn't need this argument
+endif
+
 
 # //////////
 
@@ -109,7 +117,7 @@ libData.so: $(DATAOBJS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
 	# This compiles into libData.so all the default libraries in root + all the ones in DATALIBS like lHist + RawEvent.o + DataCint.o
-	$(CC) -L $(ROOTLIBS) -shared -o"libData.so" -std=c++11 -stdlib=libc++ $(LDFLAGS) $(CXXFLAGS) $(GLIBS) $(DATAOBJS) $(DATALIBS)
+	$(CC) -L $(ROOTLIBS) -shared -o"libData.so" -std=c++11 $(STDLIB) $(LDFLAGS) $(CXXFLAGS) $(GLIBS) $(DATAOBJS) $(DATALIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 

--- a/makefile
+++ b/makefile
@@ -24,20 +24,17 @@
 
 RM := rm -rf
 OS:=$(shell uname)
-CC := g++
+
 
 # This is for Mac users
-
-ifeq ($(OS),Darwin)
-	CC := clang++
-endif
-
 # Clang allows both libc++ or libstdc++, whreas gcc supports only libstdc++, so gcc has no -stdlib command option
 
 ifeq ($(OS),Darwin)
-	STDLIB:=-stdlib=libc++
+	STDLIB := -stdlib=libc++
+	CC := clang++
 else
-	STDLIB:=  # Nothing, as Linux can't use this/doesn't need this argument
+	STDLIB :=  # Nothing, as Linux can't use this/doesn't need this argument
+	CC := g++
 endif
 
 


### PR DESCRIPTION
The last fix by Minh to the makefile for mac users broke it for Linux because the -stdlib argument does not exist for Linux's gcc. 

So, I edited the makefile to only include the -stdlib argument for mac users: https://github.com/tmnguyen87/ForStudents/commit/b09965de5e07151a5a9fe04fca0585ebcdfa2c69  
(See this stackexchange post for the error I got + the fix: https://stackoverflow.com/questions/34654682/unrecognized-command-line-option-stdlib-libc-gcc-homebrew-gcc-5-3-0-5-3-0)

(I also added more comments to files for readability / edited some of my old comments)